### PR TITLE
enable serving of static files

### DIFF
--- a/fullhouse/dashboard/templates/welcome.html
+++ b/fullhouse/dashboard/templates/welcome.html
@@ -1,9 +1,11 @@
+{% load static %}
+{% get_static_prefix as STATIC_PREFIX %}
 <!doctype html>
 <title>Full House - Welcome</title>
-<link rel="stylesheet" href="static/welcome.css" />
+<link rel="stylesheet" href="{{ STATIC_PREFIX }}welcome.css" />
 <div id="welcome">
   <div id="logo">
-    <img src="static/main-logo.png" alt="logo" />
+    <img src="{{ STATIC_PREFIX }}main-logo.png" alt="logo" />
   </div>
   <form id="login" action="login.html" method="POST">
     <div id="email">

--- a/fullhouse/settings/__init__.py
+++ b/fullhouse/settings/__init__.py
@@ -10,7 +10,7 @@ ADMINS = (
 MANAGERS = ADMINS
 
 from os.path import abspath, dirname, join
-root = join(dirname(__file__), '../')
+root = join(dirname(__file__), '../../')
 dbpath = abspath(join(root, 'database'))
 
 DATABASES = {
@@ -66,8 +66,10 @@ STATIC_ROOT = ''
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = '/static/'
 
+staticdir = abspath(join(root, 'fullhouse/static/'))
 # Additional locations of static files
 STATICFILES_DIRS = (
+    staticdir,
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
@@ -106,7 +108,7 @@ ROOT_URLCONF = 'fullhouse.urls'
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'fullhouse.wsgi.application'
 
-templatepath = abspath(join(root, 'dashboard/templates'))
+templatepath = abspath(join(root, 'fullhouse/dashboard/templates'))
 
 TEMPLATE_DIRS = (
     templatepath,

--- a/fullhouse/urls.py
+++ b/fullhouse/urls.py
@@ -15,3 +15,11 @@ urlpatterns = patterns('',
     # Uncomment the next line to enable the admin:
     # url(r'^admin/', include(admin.site.urls)),
 )
+
+
+# for debug only! django is not made to serve static files in prod
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.conf import settings
+
+if settings.DEBUG:
+  urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Note that this only works for debug/dev server. In prod,
django will not be serving static files.

Change welcome.html template to use STATIC_PREFIX.
