### PR TITLE
Add and enable django-nose for running tests, update requirements.txt

### DIFF
--- a/fullhouse/settings/__init__.py
+++ b/fullhouse/settings/__init__.py
@@ -115,7 +115,10 @@ TEMPLATE_DIRS = (
     # Don't forget to use absolute paths, not relative paths.
 )
 
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
 INSTALLED_APPS = (
+    'django_nose',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-django
+Django==1.4.1
+django-nose==1.1
+nose==1.2.1
+wsgiref==0.1.2


### PR DESCRIPTION
Can now run all project tests using `manage.py test`.
