### PR TITLE
Setup backend for login/dashboard pages, link to welcome.

### DIFF
--- a/fullhouse/dashboard/templates/dashboard.html
+++ b/fullhouse/dashboard/templates/dashboard.html
@@ -1,9 +1,11 @@
+{% load static %}
+{% get_static_prefix as STATIC_PREFIX %}
 <!DOCTYPE html>
 <html>
   <head>
     <title>Full House - Dashboard</title>
-    <link href="master.css" type="text/css" rel="stylesheet" />
-    <link href="dashboard.css" type="text/css" rel="stylesheet" />
+    <link href="{{ STATIC_PREFIX }}master.css" type="text/css" rel="stylesheet" />
+    <link href="{{ STATIC_PREFIX }}dashboard.css" type="text/css" rel="stylesheet" />
   </head>
   <body>
     <div id="nav">

--- a/fullhouse/dashboard/templates/welcome.html
+++ b/fullhouse/dashboard/templates/welcome.html
@@ -7,7 +7,8 @@
   <div id="logo">
     <img src="{{ STATIC_PREFIX }}main-logo.png" alt="logo" />
   </div>
-  <form id="login" action="login.html" method="POST">
+  <form id="login" action="login/" method="POST">
+    {% csrf_token %}
     <div id="email">
       Email: <input placeholder="Email or username" />
     </div>

--- a/fullhouse/dashboard/views.py
+++ b/fullhouse/dashboard/views.py
@@ -1,4 +1,13 @@
 from django.shortcuts import render_to_response
+from django.http import HttpResponseRedirect
+from django.template import RequestContext
 
 def welcome(request):
-    return render_to_response('welcome.html')
+    return render_to_response('welcome.html',
+        RequestContext(request, {}))
+
+def login(request):
+    return HttpResponseRedirect('/dashboard/')
+
+def dashboard(request):
+    return render_to_response('dashboard.html')

--- a/fullhouse/urls.py
+++ b/fullhouse/urls.py
@@ -4,9 +4,12 @@ from django.conf.urls import patterns, include, url
 # from django.contrib import admin
 # admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = patterns('fullhouse.dashboard',
     # Examples:
-    url(r'^$', 'fullhouse.dashboard.views.welcome', name='welcome'),
+    url(r'^$', 'views.welcome', name='welcome'),
+    url(r'^login/$', 'views.login', name='login'),
+    url(r'^dashboard/$', 'views.dashboard', name='dashboard'),
+
     # url(r'^fullhouse/', include('fullhouse.foo.urls')),
 
     # Uncomment the admin/doc line below to enable admin documentation:
@@ -22,4 +25,4 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf import settings
 
 if settings.DEBUG:
-  urlpatterns += staticfiles_urlpatterns()
+    urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
login button on welcome page posts to login view. Currently,
login view doesn't do any authentication, just redirects to
dashboard.

Made some changes to templates to link them correctly.
