### PR TITLE
Add pep8 test, fix pep8 errors

### DIFF
--- a/fullhouse/dashboard/models.py
+++ b/fullhouse/dashboard/models.py
@@ -1,4 +1,3 @@
 from django.db import models
 
 # Create your models here.
-

--- a/fullhouse/dashboard/tests/__init__.py
+++ b/fullhouse/dashboard/tests/__init__.py
@@ -4,7 +4,6 @@ when you run "manage.py test".
 
 Replace this with more appropriate tests for your application.
 """
-
 from django.test import TestCase
 
 

--- a/fullhouse/dashboard/tests/testPep8.py
+++ b/fullhouse/dashboard/tests/testPep8.py
@@ -1,0 +1,18 @@
+import pep8
+import os
+import unittest
+
+from django.conf import settings
+
+
+class Pep8Test(unittest.TestCase):
+
+    def test_pep8(self):
+
+        filepath = os.path.join(settings.PROJ_ROOT, 'fullhouse')
+
+        arglist = [filepath]
+        pep8.process_options(arglist)
+        pep8.input_dir(filepath)
+
+        self.assertEquals(pep8.get_count(), 0, 'No pep8 errors')

--- a/fullhouse/dashboard/views.py
+++ b/fullhouse/dashboard/views.py
@@ -2,18 +2,23 @@ from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
 
+
 def home(request):
     return HttpResponseRedirect('/welcome/')
+
 
 def welcome(request):
     return render_to_response('welcome.html',
         RequestContext(request, {}))
 
+
 def login(request):
     return HttpResponseRedirect('/dashboard/')
 
+
 def logout(request):
     return HttpResponseRedirect('/')
+
 
 def dashboard(request):
     return render_to_response('dashboard.html')

--- a/fullhouse/settings/__init__.py
+++ b/fullhouse/settings/__init__.py
@@ -10,17 +10,18 @@ ADMINS = (
 MANAGERS = ADMINS
 
 from os.path import abspath, dirname, join
-root = join(dirname(__file__), '../../')
-dbpath = abspath(join(root, 'database'))
+PROJ_ROOT = join(dirname(__file__), '../../')
+DB_PATH = abspath(join(PROJ_ROOT, 'database'))
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': dbpath,                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+        # 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': DB_PATH,  # Or path to database file if using sqlite3.
+        'USER': '',       # Not used with sqlite3.
+        'PASSWORD': '',   # Not used with sqlite3.
+        'HOST': '',    # Set to empty string for localhost.
+        'PORT': '',    # Set to empty string for default.
     }
 }
 
@@ -66,10 +67,10 @@ STATIC_ROOT = ''
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = '/static/'
 
-staticdir = abspath(join(root, 'fullhouse/static/'))
+STATIC_DIR = abspath(join(PROJ_ROOT, 'fullhouse/static/'))
 # Additional locations of static files
 STATICFILES_DIRS = (
-    staticdir,
+    STATIC_DIR,
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
@@ -108,19 +109,16 @@ ROOT_URLCONF = 'fullhouse.urls'
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'fullhouse.wsgi.application'
 
-templatepath = abspath(join(root, 'fullhouse/dashboard/templates'))
+templatepath = abspath(join(PROJ_ROOT, 'fullhouse/dashboard/templates'))
 
 TEMPLATE_DIRS = (
     templatepath,
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
+
 INSTALLED_APPS = (
-    'django_nose',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -131,6 +129,7 @@ INSTALLED_APPS = (
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
+    'django_nose',
 )
 
 # A sample logging configuration. The only tangible logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.4.1
 django-nose==1.1
 nose==1.2.1
+pep8==1.2
 wsgiref==0.1.2


### PR DESCRIPTION
Running './manage.py test' will now also check all source files
for pep8 compliance. Add pep8 to requirements.txt
