### PR TITLE
Add separate server requirements file

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -66,6 +66,7 @@ def release(stack, branch):
             run("git checkout " + branch)
 
         run("source env/bin/activate && pip install -r fullhouse/requirements.txt")
+        run("source env/bin/activate && pip install -r fullhouse/server_requirements.txt")
 
     run("STACK=" + stack + " STATIC_ROOT=" + static + " erb local.py.erb > " + dynamic + "fullhouse/fullhouse/settings/local.py")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pep8==1.2
 pycrypto==2.6
 ssh==1.7.14
 wsgiref==0.1.2
-psycopg2

--- a/server_requirements.txt
+++ b/server_requirements.txt
@@ -1,0 +1,1 @@
+psycopg2


### PR DESCRIPTION
This addresses #78.

Now, you can install the requirements, and it does not attempt to install the Postgres libraries, which are needed on the server, but can't be installed locally without also installing Postgres itself.
