### PR TITLE
Script to migrate existing users to new email-only users

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,64 @@
+from django.conf import settings
+from django.contrib.sites.models import RequestSite
+from django.contrib.sites.models import Site
+
+from django.contrib.auth.models import User
+from django.template.loader import (
+    get_template, render_to_string
+)
+
+from emailusernames.utils import migrate_usernames
+
+print settings.TEMPLATE_DIRS
+
+encountered_emails = set()
+duplicates = {}
+
+
+def update_duplicate_email(user):
+    email = user.email
+    username = user.username
+    email_name, domain_part = email.rsplit('@', 1)
+    email_name = '%s+%s' % (email_name, username)
+    user.email = '@'.join([email_name, domain_part])
+    user.save()
+    return username
+
+
+def send_email_update_notification(user):
+    if Site._meta.installed:
+        site = Site.objects.get_current()
+    else:
+        site = RequestSite(request)
+
+    ctx_dict = {'username': user.username,
+                'updated_email': user.email,
+                'site': site}
+    subject = render_to_string("auth_update_subject.txt", ctx_dict)
+    subject = ''.join(subject.splitlines())
+    message = render_to_string("auth_update_email.txt", ctx_dict)
+    user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+
+
+def migrate_fullhouse_usernames():
+
+    for user in User.objects.all().order_by('date_joined'):
+        email = str(user.email)
+        if email in encountered_emails:
+            username = user.username
+            update_duplicate_email(user)
+            send_email_update_notification(user)
+            if email in duplicates:
+                duplicates[email].append(user.email)
+            else:
+                duplicates[email] = [user.email]
+        else:
+              encountered_emails.update([email])
+
+    print "Updated duplicate emails for %d of %d accounts" % (
+          len(duplicates), len(encountered_emails))
+
+    migrate_usernames()
+
+
+

--- a/tools/auth_update_email.txt
+++ b/tools/auth_update_email.txt
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+{% blocktrans %}To make logging in easier, {{ site.name }} is moving to email-based
+authentication. You now just need your email and password to log in.
+
+You are receiving this email, because your account with username {{ username }} has the same email as other accounts.
+To continue using the account for {{ username }}, please use the following email to login:
+
+{{ updated_email }}
+
+Your password has not been changed, but you can change it yourself if you would like to by
+{% endblocktrans %}
+visiting http://{{ site.domain }}{% url auth_password_change %}
+
+{% trans 'Thanks for using' %} {{ site.name }}!
+
+
+
+
+
+

--- a/tools/auth_update_subject.txt
+++ b/tools/auth_update_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Changes to your account on" %} {{ site.name }}


### PR DESCRIPTION
This is a standalone tool and can be merged before or after #126, although it has some requirements to run (see requirements below. This is a one-time script to update the user models for existing users in prod to use the new email-based authentication model.

Script behavior is as follows:

Look at all users. If multiple users share an email, the first to register that email keeps it, and later users are assigned an equivalent email generated as `email_name+username@domain`. An email is then sent  to each user whose email has been changed informing them of the change.

Requires:
`django-email-as-username` must be installed (with pip), and `settings/local.py` should be edited to add the tools directory to TEMPLATE_DIRS so the templates for the email header and message can be loaded.

Usage:
To run the migration script run `./manage.py shell`. This opens the django-admin commandline. Type the following commands in and hit enter:

``` python
from tools import migrate_fullhouse_usernames
migrate_fullhouse_usernames()
```

If all succeeds you will see a message displaying counts of duplicated users patched and a message saying all usernames were successfully migrated
