### PR TITLE
Fix announcement __str__ method

### DIFF
--- a/fullhouse/dashboard/models.py
+++ b/fullhouse/dashboard/models.py
@@ -146,7 +146,7 @@ class Announcement(models.Model):
     expiration = models.DateField(null=True)
 
     def __str__(self):
-        return self.creator.__str__() + ": " + self.title
+        return self.creator.__str__() + ": " + self.text
 
     class Meta:
         ordering = ['-id']


### PR DESCRIPTION
Conor's change removed the title field in announcements, but the **str** method used it. Changed it to use the text instead.
