### PR TITLE
require zip codes to be 5 digits

### DIFF
--- a/fullhouse/dashboard/models.py
+++ b/fullhouse/dashboard/models.py
@@ -4,6 +4,7 @@ import random
 
 from django.conf import settings
 from django.core.mail import send_mail
+from django.core.validators import *
 from django.contrib.auth.models import User
 from django.contrib.sites.models import RequestSite
 from django.contrib.sites.models import Site
@@ -29,7 +30,7 @@ from registration.models import SHA1_RE
 
 class House(models.Model):
     name = models.CharField(max_length=30)
-    zip_code = models.CharField(max_length=9)
+    zip_code = models.CharField(max_length=9, validators=[RegexValidator(regex=r'^[0-9]{5}$', message="Please enter a 5 digit zip code.")])
 
     def __str__(self):
         return self.name

--- a/fullhouse/dashboard/views.py
+++ b/fullhouse/dashboard/views.py
@@ -106,6 +106,11 @@ def create_house(request):
             new_house.save()
             userprofile.house = new_house
             userprofile.save()
+        else:
+            context = RequestContext(request, {
+                'form': form,
+            })
+            return render_to_response('nonhousemember.html', context)
 
         return HttpResponseRedirect('add_members/')
 


### PR DESCRIPTION
There is an aesthetic issue with this that I don't know how to fix.

If you enter an invalid zipcode, the page reloads with the errors, but the create a house fields are hidden.
