### PR TITLE
Remove non-required fields

### DIFF
--- a/fullhouse/templates/nonhousemember.html
+++ b/fullhouse/templates/nonhousemember.html
@@ -31,11 +31,6 @@
             {{ form.name }}
           </div>
 
-          <div class="fieldWrapper">
-            {{ form.zip_code.errors }}
-            <label form="zipcode">Zip Code: </label>
-            {{ form.zip_code }}
-          </div>
           <input type="submit" value="{% trans 'Create My House' %}" />
         </form>
     </div>


### PR DESCRIPTION
Zip code is optional, so non-house-member template shouldn't have it; users can add/edit the zip code from House Settings instead.
