### PR TITLE
Redirect from auth pages when user is logged in

### DIFF
--- a/fullhouse/auth/backend/auth_urls.py
+++ b/fullhouse/auth/backend/auth_urls.py
@@ -27,16 +27,16 @@ from django.conf.urls.defaults import *
 
 from emailusernames.forms import EmailAuthenticationForm
 from django.contrib.auth import views as auth_views
+from fullhouse.auth import views as fullhouse_auth_views
 
 from fullhouse.auth.forms import (
     PasswordChangeForm, SetPasswordForm
 )
 
-
 urlpatterns = patterns(
     '',
     url(r'^login/$',
-        auth_views.login,
+        fullhouse_auth_views.login,
         {'authentication_form': EmailAuthenticationForm,
          'template_name': 'welcome.html'},
         name='auth_login'),
@@ -52,7 +52,7 @@ urlpatterns = patterns(
         auth_views.password_change_done,
         name='auth_password_change_done'),
     url(r'^password/reset/$',
-        auth_views.password_reset,
+        fullhouse_auth_views.password_reset,
         name='auth_password_reset'),
     url(r'^password/reset/confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
         auth_views.password_reset_confirm,

--- a/fullhouse/auth/tests/test_auth.py
+++ b/fullhouse/auth/tests/test_auth.py
@@ -5,9 +5,13 @@ from django.test.client import Client
 
 from django.core import mail
 
+from fullhouse.test.test_case_base import TestCaseBase
 
-class TestAuth(TestCase):
+
+class TestAuth(TestCaseBase):
     def setUp(self):
+        self.email = 'alice@eatallthecake.com'
+        self.password = 'shinyballs'
         self.client = Client()
 
     def testUnauthenticatedRedirect(self):
@@ -20,9 +24,9 @@ class TestAuth(TestCase):
 
     def testRegistration(self):
         register_data = {
-            'email': 'alice@eatallthecake.com',
-            'password1': 'shinyballs',
-            'password2': 'shinyballs',
+            'email': self.email,
+            'password1': self.password,
+            'password2': self.password,
         }
 
         # first attempt at login fails
@@ -37,40 +41,25 @@ class TestAuth(TestCase):
             []
         )
 
-        with self.settings(
-                # use the inmemory mail backend so we can get the activation url
-                # from the email
-                EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
-            # registration redirects to dashboard on success
-            response = self.client.post(
-                '/accounts/register/', follow=True, data=register_data)
-        print response
-        self.assertEqual(
-            response.redirect_chain,
-            [('http://testserver/accounts/register/complete/', 302)]
-        )
-        self.assertEqual(response.status_code, 200)
-
-        # now get the activation email and trigger activation
-        email = mail.outbox[0]
-        match = re.search(r'/accounts/activate/([a-f0-9]{40})/',
-                          str(email.message()))
-        if not match:
-            raise Exception('failed to find key in activation email')
-        activation_key = match.group(1)
-
-        response = self.client.get('/accounts/activate/%s/' % activation_key,
-                                   follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.redirect_chain,
-            [('http://testserver/accounts/activate/complete/', 302)]
-        )
+        # create user
+        self.createUser(self.email, self.password)
 
         # now login succeeds
-        response = self.client.post(
+        self.loginUser(self.email, self.password)
+
+        # login page redirects to dashboard
+        response = self.client.get(
             '/accounts/login/',
-            data={'email': 'alice@eatallthecake.com', 'password': 'shinyballs'},
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.redirect_chain,
+            [('http://testserver/dashboard/', 302)]
+        )
+        # registration page redirects to dashboard
+        response = self.client.get(
+            '/accounts/register/',
             follow=True
         )
         self.assertEqual(response.status_code, 200)

--- a/fullhouse/auth/urls.py
+++ b/fullhouse/auth/urls.py
@@ -22,7 +22,7 @@ from django.conf.urls.defaults import *
 from django.views.generic.simple import direct_to_template
 
 from registration.views import activate
-from registration.views import register
+from fullhouse.auth.views import register
 
 urlpatterns = patterns(
     '',

--- a/fullhouse/auth/views.py
+++ b/fullhouse/auth/views.py
@@ -1,0 +1,23 @@
+from django.http import HttpResponseRedirect
+from django.contrib.auth import views as auth_views
+from registration import views as registration_views
+
+from functools import wraps
+
+
+def login(request, *args, **kwargs):
+    if request.user.is_authenticated():
+        return HttpResponseRedirect('/dashboard/')
+    return auth_views.login(request, *args, **kwargs)
+
+
+def register(request, *args, **kwargs):
+    if request.user.is_authenticated():
+        return HttpResponseRedirect('/dashboard/')
+    return registration_views.register(request, *args, **kwargs)
+
+
+def password_reset(request, *args, **kwargs):
+    if request.user.is_authenticated():
+        return HttpResponseRedirect('/accounts/password/change/')
+    return auth_views.password_reset(request, *args, **kwargs)

--- a/fullhouse/test/test_password_change.py
+++ b/fullhouse/test/test_password_change.py
@@ -1,5 +1,4 @@
 from django.test.client import Client
-from django.core import mail
 import test_case_base
 
 
@@ -15,7 +14,6 @@ class TestPasswordChange(test_case_base.TestCaseBase):
 
     def test_password_change(self):
 
-        mail.outbox = []
         # Write out a new password
         response = self.client.post(
             '/accounts/password/change/',

--- a/fullhouse/test/test_password_recovery.py
+++ b/fullhouse/test/test_password_recovery.py
@@ -63,3 +63,17 @@ class TestPasswordRecovery(test_case_base.TestCaseBase):
         self.loginUser(self.email, self.newpassword)
         # ensure the user is now logged in with new password
         self.assertEqual(self.client.session['_auth_user_id'], user.pk)
+
+    def test_redirect(self):
+        """
+        test that password recovery logged in user to password change
+        """
+        self.loginUser(self.email, self.password)
+        response = self.client.get(
+            '/accounts/password/reset/',
+            follow=True
+        )
+        self.assertEqual(
+            response.redirect_chain,
+            [('http://testserver/accounts/password/change/', 302)]
+        )


### PR DESCRIPTION
login and register redirect authenticated users to dashboard,
password_reset redirects authenticated user to password_change

update tests to cover/reflect this change

This closes #177
