### PR TITLE
Fixed bug with inviteProfile

### DIFF
--- a/fullhouse/dashboard/models.py
+++ b/fullhouse/dashboard/models.py
@@ -60,7 +60,7 @@ class InviteManager(models.Manager):
                 profile = user.profile
                 profile.house = invite.house
                 profile.save()
-                invite.activation_key = self.model.INVITE_ACCEPTED
+                invite.invite_key = self.model.INVITE_ACCEPTED
                 invite.save()
                 return user
         return False


### PR DESCRIPTION
InviteProfile was not updating the invite_key when users accept
house invite. Didn't break anything, but made it more difficult
to tell when a user has accepted an invite.
