### PR TITLE
Style tweaks for #main and house_settings.

### DIFF
--- a/fullhouse/static/dashboard.css
+++ b/fullhouse/static/dashboard.css
@@ -59,15 +59,3 @@
   padding-left: 10px;
 }
 
-
-#main {
-  background-color: white;
-  height: 450px;
-  margin: auto;
-  padding-top: 35px;
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-bottom: 20px;
-  width: 70%;
-}
-

--- a/fullhouse/static/house_settings.css
+++ b/fullhouse/static/house_settings.css
@@ -1,11 +1,6 @@
 #house-settings {
   display: inline-block;
   padding: 20px;
-  text-align: right;
-}
-
-#house-settings h1 {
-  padding-left: 10px;
 }
 
 #house-settings input[type="text"] {
@@ -13,6 +8,6 @@
 }
 
 #house-settings-submit {
-  padding: 5px;
+  padding: 5px 0;
   text-align: left;
 }

--- a/fullhouse/static/main.css
+++ b/fullhouse/static/main.css
@@ -47,6 +47,7 @@ ul.nav {
   background-color: white;
   height: 100%;
   margin: auto;
+  overflow: auto;
   padding-top: 35px;
   padding-left: 10px;
   padding-right: 10px;

--- a/fullhouse/templates/house_settings.html
+++ b/fullhouse/templates/house_settings.html
@@ -27,24 +27,7 @@
           <input type="submit" value="{% trans 'Save House Settings' %}" />
         </div>
 
-        {{ form.non_field_errors }}
-        <div class="fieldWrapper">
-          {{ form.name.errors }}
-          <label form="housename">House Name: </label>
-          {{ form.name }}
-        </div>
-
-        <div class="fieldWrapper">
-          {{ form.zip_code.errors }}
-          <label form="zipcode">Zip Code: </label>
-          {{ form.zip_code }}
-        </div>
-
-        <div class="fieldWrapper">
-          {{ form.remove_from_house.errors }}
-          <label form="remove_from_house">{{ form.remove_from_house.label }}: </label>
-          {{ form.remove_from_house }}
-        </div>
+        {{ form.as_p }}
 
         <script src="{{ STATIC_PREFIX }}add_members.js" ></script>
         <div id="addmembers">


### PR DESCRIPTION
Removed hardcoded height for dashboard and set #main to handle overflow.
Aligned house settings to the left. Looks better than the awkward align right we had before. We need to discuss the look and feel of forms for 1.B.
