### PR TITLE
Correctly name missing activate template

### DIFF
--- a/fullhouse/templates/registration/activate.html
+++ b/fullhouse/templates/registration/activate.html
@@ -5,6 +5,6 @@
     <p>{% trans "Account successfully activated" %}</p>
     <p><a href="{% url auth_login %}">{% trans "Log in" %}</a></p>
 {% else %}
-    <p>{% trans "Account activation failed" %}</p>
+    <p>{% trans "Activation key is expired or invalid" %}</p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
If user clicks activation links multiple times, the second+ times a message is displayed saying activation key expired or invalid. (first time works as normal of course) fixes #226
