### PR TITLE
Allow users to edit next due date of tasks

### DIFF
--- a/fullhouse/dashboard/models.py
+++ b/fullhouse/dashboard/models.py
@@ -339,7 +339,7 @@ class Task(models.Model):
     is_active = models.BooleanField(default=False)
 
     title = models.CharField(max_length=100)
-    description = models.TextField(null=True)
+    description = models.TextField(null=True, blank=True)
     frequency = models.CharField(
         max_length=4, choices=FREQUENCY_CHOICES, default=ONCE
     )

--- a/fullhouse/templates/edit_task.html
+++ b/fullhouse/templates/edit_task.html
@@ -19,6 +19,8 @@
       {{ form.non_field_errors }}
       <input type="hidden" name="id" value="{{ id }}" />
 
+      {{ form.as_p }}
+      {% comment %}
       <div class = "fieldWrapper">
         {{ form.title.errors }}
         <label form="title">Title: </label>
@@ -48,6 +50,7 @@
         <label form="first_due">First Due (MM-DD-YYYY): </label>
         {{ form.first_due }}
       </div>
+      {% endcomment %}
 
       <input type="submit" name="save" value="{% trans 'Save Changes' %}" />
       <input type="submit" name="discontinue" value="{% trans 'Discontinue' %}" />


### PR DESCRIPTION
Choose a first due date on task creation. On task edit, first due
is hidden and uneditable; instead user can edit the next due date
which changes the due date of the current instance
Also update task tests

Resolves #241
