### PR TITLE
Fixed whitespace problems in the invite email.

### DIFF
--- a/fullhouse/templates/addmembers/invite_email.txt
+++ b/fullhouse/templates/addmembers/invite_email.txt
@@ -7,19 +7,13 @@
 http://{{ site.domain }}{% url fullhouse.dashboard.views.join_house invite_key %}
 
 {% if members|length != 0 %}
-  Current house members:
-  {% for member in members %}
-    {{ member }}
-  {% endfor %}
-{% endif %}
-
+Current house members:
+{% for member in members %}- {{ member }}
+{% endfor %}{% endif %}
 {% if invitees|length != 0 %}
-  Other invited members:
-  {% for invitee in invitees %}
-    {{ invitee }}
-  {% endfor %}
-{% endif %}
-
+Other invited members:
+{% for invitee in invitees %}- {{ invitee }}
+{% endfor %}{% endif %}
 {% blocktrans %}
 Full House is your digital kitchen whiteboard, your electronic solution for efficient communication
 between you and the people you live with. Post announcements, organize your tasks, and more; get


### PR DESCRIPTION
I modified the invite email so the whitespace output looks decent, although I had to butcher the file itself. The {% spaceless %} tag was useless because I still needed newlines...

Sample output below.

bob@bob.com has invited you to join a house on 127.0.0.1:8000:

House: Dummy2

Click the link below to join this house!
http://127.0.0.1:8000/dashboard/join_house/b10c3ad2434fe5d21141745593b2d9200a5e3ecf/

Current house members:
- bob@bob.com
- test@bob.com
- jim@bob.com

Other invited members:
- lol@bob.com

Full House is your digital kitchen whiteboard, your electronic solution for efficient communication
between you and the people you live with. Post announcements, organize your tasks, and more; get
started with Full House today!

Link is valid for 7 days.
